### PR TITLE
Remove simple leading and trailing punctuation from words

### DIFF
--- a/input_filtering/src/input_filter.py
+++ b/input_filtering/src/input_filter.py
@@ -1,3 +1,5 @@
+import re
+
 class InputFilter:
     def __init__(self, raw_data):
         self.data = raw_data
@@ -6,7 +8,14 @@ class InputFilter:
         return list(self.data)
 
     def get_words(self):
-        return self.data.split(" ")
+        """
+        Returns a list of all the words contained in the data, with most
+        standard English punctuation removed from the ends of each word.
+        """
+        L = self.data.split(" ")
+        for i in range(len(L)):
+            L[i] = re.sub(r"\A[.,;:\"\']+|[.,;:\"\']+\Z", "", L[i])
+        return L
 
     def get_sentences(self):
         return self.data.split(". ")

--- a/input_filtering/tests/test_get_words.py
+++ b/input_filtering/tests/test_get_words.py
@@ -1,0 +1,14 @@
+import unittest
+from text_analysis.input_filtering.src.input_filter import InputFilter
+
+class TestGetWords(unittest.TestCase):
+  def test_trailingPeriods(self):
+    if1 = InputFilter('Simple string. Doesn\'t have punctuation, and stuff.')
+    res1 = if1.get_words()
+    self.assertEqual(res1, ['Simple', 'string', 'Doesn\'t', 'have', 'punctuation', 'and', 'stuff'])
+  
+  def test_miscPunctuation(self):
+    if2 = InputFilter('Handles ellipsis..., lists: of, things, and semicolons; plus-dashes')
+    res2 = if2.get_words()
+    self.assertEqual(res2, ['Handles', 'ellipsis', 'lists', 'of', 'things', 'and', 'semicolons', 'plus-dashes'])
+


### PR DESCRIPTION
## Related issue (if applicable):

Changes proposed in this pull request:
- Run a regex sub() after splitting array to remove most standard English punctuation from the start and end of words.
- Include test cases

Capital of Assyria:
Aššur
--


